### PR TITLE
Fixed the problem when setting zero_stats to 1 twice.

### DIFF
--- a/Driver/enhanceio/eio_procfs.c
+++ b/Driver/enhanceio/eio_procfs.c
@@ -88,9 +88,8 @@ eio_zerostats_sysctl(struct ctl_table *table, int write, void __user *buffer,
 			return -EINVAL;
 		}
 
-		if (dmc->sysctl_pending.zerostats ==
-		    dmc->sysctl_active.zerostats)
-			/* same value. Nothing to work */
+		if (!dmc->sysctl_pending.zerostats)
+			/* if 0 do nothing */
 			return 0;
 
 		/* Copy to active */
@@ -1055,7 +1054,7 @@ static struct sysctl_table_common {
 		{               /* 1 */
 			.procname	= "zero_stats",
 			.maxlen		= sizeof(int),
-			.mode		= 0644,
+			.mode		= 0200,
 			.proc_handler	= &eio_zerostats_sysctl,
 		}, {            /* 2 */
 			.procname	= "mem_limit_pct",


### PR DESCRIPTION
When you set zero_stats to 1, twice in a row, it doesn't work in the second time. This pull, fixes this issue.
