### PR TITLE
Compile fix for centos 7.3

### DIFF
--- a/Driver/enhanceio/Makefile
+++ b/Driver/enhanceio/Makefile
@@ -39,7 +39,7 @@ enhanceio_fifo-y	+= eio_fifo.o
 enhanceio_rand-y	+= eio_rand.o
 enhanceio_lru-y	+= eio_lru.o
 .PHONY: all
-all: modules 
+all: modules
 .PHONY:    modules
 modules: $(RHEL5_SETUP)
 	make -C $(KERNEL_TREE) M=$(PWD) modules V=0

--- a/Driver/enhanceio/Makefile
+++ b/Driver/enhanceio/Makefile
@@ -8,7 +8,7 @@ KERNEL_TREE ?= /lib/modules/$(KERNEL_SOURCE_VERSION)/build
 EXTRA_CFLAGS += -I$(KERNEL_TREE)/drivers/md -I./ -DCOMMIT_REV="\"$(COMMIT_REV)\""
 EXTRA_CFLAGS += -I$(KERNEL_TREE)/include/ -I$(KERNEL_TREE)/include/linux 
 # Check for RHEL/CentOS
-RHEL5_VER ?= $(shell  if [ -e /etc/redhat-release ]; then grep 5.[0-9] /etc/redhat-release; else false; fi)
+RHEL5_VER ?= $(shell  if [ -e /etc/redhat-release ]; then grep 5\\.[0-9] /etc/redhat-release; else false; fi)
 RHEL5_SETUP :=
 ifneq "$(RHEL5_VER)" ""
 	RHEL5_SETUP := rhel5-setup

--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -61,6 +61,13 @@
 #include <linux/vmalloc.h>      /* for sysinfo (mem) variables */
 #include <linux/mm.h>
 #include <scsi/scsi_device.h>   /* required for SSD failure handling */
+
+/* we use RHEL_RELEASE_VERSION to compile with RHEL/CentOS 7.3's kernel  */
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_CODE 0
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+#endif
+
 /* resolve conflict with scsi/scsi_device.h */
 #ifdef QUEUED
 #undef QUEUED
@@ -129,8 +136,8 @@ struct eio_control_s {
 	unsigned long synch_flags;
 };
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 int eio_wait_schedule(struct wait_bit_key *, int);
 #else
 int eio_wait_schedule(struct wait_bit_key *);

--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -89,8 +89,8 @@ static struct notifier_block eio_ssd_rm_notifier = {
 	.priority	= 0,
 };
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 int eio_wait_schedule(struct wait_bit_key *unused, int unused2)
 #else
 int eio_wait_schedule(struct wait_bit_key *unused)

--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -90,7 +90,11 @@ static struct notifier_block eio_ssd_rm_notifier = {
 };
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
+int eio_wait_schedule(struct wait_bit_key *unused, int unused2)
+#else
 int eio_wait_schedule(struct wait_bit_key *unused)
+#endif
 #else
 #define wait_on_bit_lock_action wait_on_bit_lock
 int eio_wait_schedule(void *unused)
@@ -805,7 +809,7 @@ static int eio_md_create(struct cache_c *dmc, int force, int cold)
 
 		for (i = 0; i < dmc->size; i++) {
 			next_ptr->dbn = cpu_to_le64(EIO_DBN_GET(dmc, i));
-			next_ptr->cache_state = 
+			next_ptr->cache_state =
 				cpu_to_le64(EIO_CACHE_STATE_GET(dmc,
 				(index_t)i) & (INVALID | VALID | DIRTY));
 			next_ptr++;
@@ -1130,7 +1134,7 @@ static int eio_md_load(struct cache_c *dmc)
 
 	if (!dmc->cache_flags)
 		dmc->cache_flags = le32_to_cpu(header->sbf.cache_flags);
-	
+
 	error = eio_policy_init(dmc);
 	if (error)
 		goto free_header;
@@ -1678,7 +1682,7 @@ int eio_cache_create(struct cache_rec_short *cache)
 			strerr = "Failed to initialize policy";
 			goto bad5;
 		}
-	}	
+	}
 
 	if (cache->cr_flags) {
 		int flags;
@@ -2181,7 +2185,7 @@ int eio_ctr_ssd_add(struct cache_c *dmc, char *dev)
 	dmc->persistence = CACHE_FORCECREATE;
 
 	eio_policy_free(dmc);
-	r = eio_policy_init(dmc); 
+	r = eio_policy_init(dmc);
 	if (r) {
 		pr_err("ctr_ssd_add: Failed to initialize policy");
 		goto out;

--- a/Driver/enhanceio/eio_main.c
+++ b/Driver/enhanceio/eio_main.c
@@ -2386,7 +2386,7 @@ static int eio_acquire_set_locks(struct cache_c *dmc, struct bio_container *bc)
 				spin_lock_irqsave(&set->cs_lock, flags);
 			}
 			if (atomic_inc_return(&set->pending) == 1)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 				reinit_completion(&(set->io_done));
 #else
 				INIT_COMPLETION(set->io_done);
@@ -3358,7 +3358,7 @@ eio_clean_set(struct cache_c *dmc, index_t set, int whole, int force)
 	/* 1. exclusive lock. Let the ongoing writes to finish. Pause new writes */
 	spin_lock_irqsave(&dmc->cache_sets[set].cs_lock, flags);
 	dmc->cache_sets[set].flags |= SETFLAG_CLEAN_ACTIVE;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 	reinit_completion(&dmc->cache_sets[set].clean_done);
 #else
 	INIT_COMPLETION(dmc->cache_sets[set].clean_done);
@@ -3473,7 +3473,7 @@ eio_clean_set(struct cache_c *dmc, index_t set, int whole, int force)
 	 * I/Os.
 	 */
 	atomic_set(&sioc.pending, 1);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 	reinit_completion(&sioc.done);
 #else
 	INIT_COMPLETION(sioc.done);

--- a/Driver/enhanceio/eio_main.c
+++ b/Driver/enhanceio/eio_main.c
@@ -95,9 +95,9 @@ static void bc_put(struct bio_container *bc, unsigned int doneio)
 			eio_release_io_resources(bc->bc_dmc, bc);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		bc->bc_bio->bi_iter.bi_size = 0;
-#else 
+#else
 		bc->bc_bio->bi_size = 0;
-#endif 
+#endif
 		dmc = bc->bc_dmc;
 
 		/* update iotime for latency */
@@ -2012,9 +2012,9 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 	if (residual_biovec) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		int bvecindex = bio->bi_iter.bi_idx;
-#else 
+#else
 		int bvecindex = bio->bi_idx;
-#endif 
+#endif
 		int rbvindex;
 
 		/* Calculate the number of bvecs required */
@@ -2054,7 +2054,7 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 			ebio->eb_rbv[rbvindex].bv_len =
 				bio->bi_io_vec[bio->bi_iter.bi_idx].bv_len -
 				residual_biovec;
-#else 
+#else
 			ebio->eb_rbv[rbvindex].bv_page =
 				bio->bi_io_vec[bio->bi_idx].bv_page;
 			ebio->eb_rbv[rbvindex].bv_offset =
@@ -2063,7 +2063,7 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 			ebio->eb_rbv[rbvindex].bv_len =
 				bio->bi_io_vec[bio->bi_idx].bv_len -
 				residual_biovec;
-#endif 
+#endif
 			if (ebio->eb_rbv[rbvindex].bv_len > (unsigned)ios) {
 				residual_biovec += ios;
 				ebio->eb_rbv[rbvindex].bv_len = ios;
@@ -2071,9 +2071,9 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 				residual_biovec = 0;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 				bio->bi_iter.bi_idx++;
-#else 
+#else
 				bio->bi_idx++;
-#endif 
+#endif
 			}
 			ios -= ebio->eb_rbv[rbvindex].bv_len;
 			rbvindex++;
@@ -2087,27 +2087,27 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 			return ERR_PTR(-ENOMEM);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		ebio->eb_bv = bio->bi_io_vec + bio->bi_iter.bi_idx;
-#else 
+#else
 		ebio->eb_bv = bio->bi_io_vec + bio->bi_idx;
-#endif 
+#endif
 		ios = iosize;
 		while (ios > 0) {
 			numbvecs++;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 			if ((unsigned)ios < bio->bi_io_vec[bio->bi_iter.bi_idx].bv_len) {
-#else 
+#else
 			if ((unsigned)ios < bio->bi_io_vec[bio->bi_idx].bv_len) {
-#endif 
+#endif
 				residual_biovec = ios;
 				ios = 0;
 			} else {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 				ios -= bio->bi_io_vec[bio->bi_iter.bi_idx].bv_len;
 				bio->bi_iter.bi_idx++;
-#else 
+#else
 				ios -= bio->bi_io_vec[bio->bi_idx].bv_len;
 				bio->bi_idx++;
-#endif 
+#endif
 			}
 		}
 	}
@@ -2149,13 +2149,13 @@ eio_disk_io(struct cache_c *dmc, struct bio *bio,
 	ebio =
 		eio_new_ebio(dmc, bio, &residual_biovec, bio->bi_iter.bi_sector,
 				 bio->bi_iter.bi_size, bc, EB_MAIN_IO);
-#else 
+#else
 	/*disk io happens on whole bio. Reset bi_idx*/
 	bio->bi_idx = 0;
 	ebio =
 		eio_new_ebio(dmc, bio, &residual_biovec, bio->bi_sector,
 			     bio->bi_size, bc, EB_MAIN_IO);
-#endif 
+#endif
 
 	if (unlikely(IS_ERR(ebio))) {
 		bc->bc_error = error = PTR_ERR(ebio);
@@ -2177,17 +2177,17 @@ eio_disk_io(struct cache_c *dmc, struct bio *bio,
 		job->action = READDISK;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		SECTOR_STATS(dmc->eio_stats.disk_reads, bio->bi_iter.bi_size);
-#else 
+#else
 		SECTOR_STATS(dmc->eio_stats.disk_reads, bio->bi_size);
-#endif 
+#endif
 		atomic64_inc(&dmc->eio_stats.readdisk);
 	} else {
 		job->action = WRITEDISK;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		SECTOR_STATS(dmc->eio_stats.disk_writes, bio->bi_iter.bi_size);
-#else 
+#else
 		SECTOR_STATS(dmc->eio_stats.disk_writes, bio->bi_size);
-#endif 
+#endif
 		atomic64_inc(&dmc->eio_stats.writedisk);
 	}
 
@@ -2211,9 +2211,9 @@ eio_disk_io(struct cache_c *dmc, struct bio *bio,
 errout:
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 	eio_inval_range(dmc, bio->bi_iter.bi_sector, bio->bi_iter.bi_size);
-#else 
+#else
 	eio_inval_range(dmc, bio->bi_sector, bio->bi_size);
-#endif 
+#endif
 	eio_flag_abios(dmc, anchored_bios, error);
 
 	if (ebio)
@@ -2320,11 +2320,11 @@ static int eio_acquire_set_locks(struct cache_c *dmc, struct bio_container *bc)
 	round_sector = EIO_ROUND_SET_SECTOR(dmc, bio->bi_iter.bi_sector);
 	set_size = dmc->block_size * dmc->assoc;
 	end_sector = bio->bi_iter.bi_sector + eio_to_sector(bio->bi_iter.bi_size);
-#else 
+#else
 	round_sector = EIO_ROUND_SET_SECTOR(dmc, bio->bi_sector);
 	set_size = dmc->block_size * dmc->assoc;
 	end_sector = bio->bi_sector + eio_to_sector(bio->bi_size);
-#endif 
+#endif
 	first_set = -1;
 	last_set = -1;
 	cur_set = -1;
@@ -2537,9 +2537,9 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 	sector_t sectors = eio_to_sector(bio->bi_iter.bi_size);
-#else 
+#else
 	sector_t sectors = eio_to_sector(bio->bi_size);
-#endif 
+#endif
 	struct eio_bio *ebio = NULL;
 	struct bio_container *bc;
 	sector_t snum;
@@ -2557,9 +2557,9 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 	EIO_ASSERT(bio->bi_iter.bi_idx == 0);
-#else 
+#else
 	EIO_ASSERT(bio->bi_idx == 0);
-#endif 
+#endif
 
 	pr_debug("this needs to be removed immediately\n");
 
@@ -2573,12 +2573,12 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 			("eio_map: Discard IO received. Invalidate incore start=%lu totalsectors=%d.\n",
 			(unsigned long)bio->bi_iter.bi_sector,
 			(int)eio_to_sector(bio->bi_iter.bi_size));
-#else 
+#else
 		pr_debug
 			("eio_map: Discard IO received. Invalidate incore start=%lu totalsectors=%d.\n",
 			(unsigned long)bio->bi_sector,
 			(int)eio_to_sector(bio->bi_size));
-#endif 
+#endif
 		eio_bio_endio(bio, 0);
 		pr_err
 			("eio_map: I/O with Discard flag received. Discard flag is not supported.\n");
@@ -2600,16 +2600,16 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 	if (data_dir == READ) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		SECTOR_STATS(dmc->eio_stats.reads, bio->bi_iter.bi_size);
-#else 
+#else
 		SECTOR_STATS(dmc->eio_stats.reads, bio->bi_size);
-#endif 
+#endif
 		atomic64_inc(&dmc->eio_stats.readcount);
 	} else {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		SECTOR_STATS(dmc->eio_stats.writes, bio->bi_iter.bi_size);
-#else 
+#else
 		SECTOR_STATS(dmc->eio_stats.writes, bio->bi_size);
-#endif 
+#endif
 		atomic64_inc(&dmc->eio_stats.writecount);
 	}
 
@@ -2649,9 +2649,9 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 	 */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 	if (bio->bi_iter.bi_size == 0) {
-#else 
+#else
 	if (bio->bi_size == 0) {
-#endif 
+#endif
 		eio_process_zero_size_bio(dmc, bio);
 		return DM_MAPIO_SUBMITTED;
 	}
@@ -2674,11 +2674,11 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 	snum = bio->bi_iter.bi_sector;
 	totalio = bio->bi_iter.bi_size;
 	biosize = bio->bi_iter.bi_size;
-#else 
+#else
 	snum = bio->bi_sector;
 	totalio = bio->bi_size;
 	biosize = bio->bi_size;
-#endif 
+#endif
 	residual_biovec = 0;
 
 	if (dmc->mode == CACHE_MODE_WB) {
@@ -2861,7 +2861,7 @@ static int eio_read_peek(struct cache_c *dmc, struct eio_bio *ebio)
 		goto out;
 	}
 	EIO_ASSERT(res == INVALID);
-	
+
 	/* cache is marked readonly or set to wronly mode. */
 	/* Do not allow READFILL on SSD */
 	if (dmc->cache_rdonly || dmc->sysctl_active.cache_wronly)

--- a/Driver/enhanceio/eio_mem.c
+++ b/Driver/enhanceio/eio_mem.c
@@ -26,18 +26,18 @@
 #define SECTORS_PER_SET_SHIFT   (dmc->consecutive_shift + dmc->block_shift)
 #define SECTORS_PER_SET_MASK    (SECTORS_PER_SET - 1)
 
-#define EIO_DBN_TO_SET(dmc, dbn, set_number, wrapped)   do {		\
-		u_int64_t value;						\
-		u_int64_t mid_i;						\
-		value = (dbn) >> SECTORS_PER_SET_SHIFT;				\
-		mid_i = (value) & (dmc)->num_sets_mask;				\
-		if (mid_i >= (dmc)->num_sets) {					\
-			(wrapped) = 1;						\
-			(set_number) = mid_i - (dmc)->num_sets;			\
-		} else {							\
-			(wrapped) = 0;						\
-			(set_number) = mid_i;					\
-		}								\
+#define EIO_DBN_TO_SET(dmc, dbn, set_number, wrapped)   do {	\
+		u_int64_t value;				\
+		u_int64_t mid_i;				\
+		value = (dbn) >> SECTORS_PER_SET_SHIFT;		\
+		mid_i = (value) & (dmc)->num_sets_mask;		\
+		if (mid_i >= (dmc)->num_sets) {			\
+			(wrapped) = 1;				\
+			(set_number) = mid_i - (dmc)->num_sets;	\
+		} else {					\
+			(wrapped) = 0;				\
+			(set_number) = mid_i;			\
+		}						\
 } while (0)
 
 /*

--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -32,7 +32,7 @@
 #include "eio.h"
 #include "eio_ttc.h"
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,3))
 #define wait_on_bit_lock_action wait_on_bit_lock
 #endif
 

--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -47,7 +47,11 @@ static struct list_head eio_ttc_list[EIO_HASHTBL_SIZE];
 int eio_reboot_notified;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,2,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
+static blk_qc_t eio_make_request_fn(struct request_queue *, struct bio *);
+#else
 static void eio_make_request_fn(struct request_queue *, struct bio *);
+#endif
 #else
 static int eio_make_request_fn(struct request_queue *, struct bio *);
 #endif
@@ -412,7 +416,11 @@ void eio_ttc_init(void)
  */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,2,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
+static blk_qc_t eio_make_request_fn(struct request_queue *q, struct bio *bio)
+#else
 static void eio_make_request_fn(struct request_queue *q, struct bio *bio)
+#endif
 #else
 static int eio_make_request_fn(struct request_queue *q, struct bio *bio)
 #endif
@@ -541,7 +549,11 @@ re_lookup:
 
 	if (overlap || dmc)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,2,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
+		return BLK_QC_T_NONE;
+#else
 		return;
+#endif
 #else
 		return 0;
 #endif
@@ -565,7 +577,11 @@ re_lookup:
 
 	hdd_make_request(origmfn, bio);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,2,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
+	return BLK_QC_T_NONE;
+#else
 	return;
+#endif
 #else
 	return 0;
 #endif
@@ -1352,7 +1368,7 @@ static int eio_policy_switch(struct cache_c *dmc, u_int32_t policy)
 
 	EIO_ASSERT(dmc->req_policy != policy);
 	old_policy_ops = dmc->policy_ops;
-	
+
 	error = eio_policy_init(dmc);
 	if (error)
 		goto out;


### PR DESCRIPTION
RHEL(and Centos) 7.3 use some kernel patch backport from 4.4 or newer, so I've make those fix to make it compiled on Centos 7.3.
Also this version is compile clear on Debain/Proxmox 4.4.21, Centos 7.2.

I've try WT mode in AWS c3.xlarge with fio, xfs file system, 7200 secs rangrw test, no error report.