### PR TITLE
Reverted cache set locking changes

### DIFF
--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -43,7 +43,6 @@
 #include <linux/hash.h>
 #include <linux/spinlock.h>
 #include <linux/workqueue.h>
-#include <linux/completion.h>
 #include <linux/pagemap.h>
 #include <linux/random.h>
 #include <linux/hardirq.h>
@@ -577,16 +576,13 @@ struct mdupdate_request {
 
 #define SETFLAG_CLEAN_INPROG    0x00000001      /* clean in progress on a set */
 #define SETFLAG_CLEAN_WHOLE     0x00000002      /* clean the set fully */
-#define SETFLAG_CLEAN_ACTIVE    0x00000004      /* cache set is being cleaned up */
 
 /* Structure used for doing operations and storing cache set level info */
 struct cache_set {
 	struct list_head list;
 	u_int32_t nr_dirty;             /* number of dirty blocks */
 	spinlock_t cs_lock;             /* spin lock to protect struct fields */
-	atomic_t pending;               /* pending I/Os on cache set */
-	struct completion clean_done;   /* Clean operation on set has been completed */
-	struct completion io_done;      /* all IO operations on set have been completed */
+	struct rw_semaphore rw_lock;    /* lock for cache set clean */
 	unsigned int flags;             /* misc cache set specific flags */
 	struct mdupdate_request *mdreq; /* metadata update request pointer */
 };

--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -1816,9 +1816,7 @@ init:
 	for (i = 0; i < (dmc->size >> dmc->consecutive_shift); i++) {
 		dmc->cache_sets[i].nr_dirty = 0;
 		spin_lock_init(&dmc->cache_sets[i].cs_lock);
-		atomic_set(&dmc->cache_sets[i].pending, 0);
-		init_completion(&dmc->cache_sets[i].clean_done);
-		init_completion(&dmc->cache_sets[i].io_done);
+		init_rwsem(&dmc->cache_sets[i].rw_lock);
 		dmc->cache_sets[i].mdreq = NULL;
 		dmc->cache_sets[i].flags = 0;
 	}


### PR DESCRIPTION
The new cache set locking which was compatible with lockdep acutally did not work in rare caces and produced kernel oopses. The locking mechanism has been thus reverted to the original one.