### PR TITLE
Avoid the race condition in CLI/eio_cli

### DIFF
--- a/CLI/eio_cli
+++ b/CLI/eio_cli
@@ -23,6 +23,7 @@ from fcntl import *
 from argparse import ArgumentParser
 import sys,struct
 import subprocess
+import fcntl
 import os
 import re
 
@@ -562,6 +563,9 @@ def main():
 	run_cmd("/sbin/modprobe enhanceio_fifo")
 	run_cmd("/sbin/modprobe enhanceio_lru")
 	run_cmd("/sbin/modprobe enhanceio_rand")
+
+	f = open("/run/eio.lock", "w")
+	fcntl.flock(f, fcntl.LOCK_EX)
 
 	if sys.argv[1] == "create":
 

--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -652,6 +652,8 @@ struct eio_stats {
 #define MIN_JOBS                                1024
 #define MIN_EIO_IO                              4096
 #define MIN_DMC_BIO_PAIR                        8192
+#define COUNT_SECONDS                           2
+#define COUNT_MAX_ERRORS                        30
 
 /* Structure representing a sequence of sets(first to last set index) */
 struct set_seq {
@@ -755,6 +757,8 @@ struct cache_c {
 	int readfill_in_prog;
 	struct eio_stats eio_stats;     /* Run time stats */
 	struct eio_errors eio_errors;   /* Error stats */
+	int countErrors[COUNT_SECONDS]; /* Count errors in last N secconds*/
+	struct timeval lasttime;
 	int clean_inprog;
 	atomic64_t nr_dirty;
 	atomic64_t nr_ios;


### PR DESCRIPTION
When the system boots, the cache is not created. The error message is at the end of the post. In order to avoid of race conditions I propose to create a lock before execution of any commands.

[   15.155523] enhanceio: Allocate 4558122KB (4B per) mem for 1166879232-entry cache (capacity:4575927MB, associativity:256, block size:4096 bytes)
[   44.023658] enhanceio: Cache metadata loaded from disk with 26219124 valid 0 dirty blocks
[   44.023661] enhanceio: Setting mode to read only 
[   44.023662] enhanceio: Cache metadata loaded from disk with 26219124 valid 0 dirty blocks
[   44.023664] enhanceio: Setting mode to read only 
[   44.094552] enhanceio_lru: Initialized 4558122 sets in LRU
[   44.094556] enhanceio_lru: Initialized 4558122 sets in LRU
[   61.523173] ------------[ cut here ]------------
[   61.523180] WARNING: CPU: 15 PID: 808 at fs/proc/generic.c:414 proc_register+0xf6/0x130
[   61.523181] proc_dir_entry 'enhanceio/bigcache' already registered
[   61.523182] Modules linked in: iTCO_wdt iTCO_vendor_support sb_edac enhanceio_rand(OE) edac_core intel_powerclamp coretemp enhanceio_lru(OE) intel_rapl iosf_mbi enhanceio_fifo(OE) kvm_intel enhanceio(OE) kvm irqbypass crc32_pclmul ghash_clmulni_intel aesni_intel lrw gf128mul glue_helper ablk_helper cryptd ses enclosure pcspkr joydev sg mei_me i2c_i801 mei lpc_ich ioatdma shpchp wmi ipmi_si ipmi_devintf ipmi_msghandler acpi_power_meter acpi_pad ip_tables ext4 mbcache jbd2 sd_mod crc_t10dif crct10dif_generic ast drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops ttm ahci i40e mpt3sas libahci igb drm libata crct10dif_pclmul crct10dif_common megaraid_sas crc32c_intel dca i2c_algo_bit raid_class ptp i2c_core scsi_transport_sas pps_core
[   61.523215] CPU: 15 PID: 808 Comm: eio_cli Tainted: G           OE  ------------   3.10.0-693.17.1.el7.broadwell.x86_64 #1
[   61.523216] Hardware name: Supermicro Super Server/X10SRH-CF, BIOS 2.0b 04/14/2017
[   61.523216] Call Trace:
[   61.523222]  [<ffffffff8169b837>] dump_stack+0x19/0x1b
[   61.523226]  [<ffffffff81088f18>] __warn+0xd8/0x100
[   61.523228]  [<ffffffff81088f9f>] warn_slowpath_fmt+0x5f/0x80
[   61.523230]  [<ffffffff81274cb8>] ? pde_subdir_insert+0x58/0xb0
[   61.523231]  [<ffffffff81274f46>] proc_register+0xf6/0x130
[   61.523233]  [<ffffffff81275082>] proc_mkdir_data+0x52/0x80
[   61.523234]  [<ffffffff812750e5>] proc_mkdir+0x15/0x20
[   61.523239]  [<ffffffffc044566e>] eio_procfs_ctr+0x2e/0x220 [enhanceio]
[   61.523241]  [<ffffffffc043c37f>] eio_cache_create+0xa1f/0xb60 [enhanceio]
[   61.523243]  [<ffffffffc043c8df>] eio_ioctl+0x2df/0x310 [enhanceio]
[   61.523247]  [<ffffffff8121465d>] do_vfs_ioctl+0x33d/0x540
[   61.523251]  [<ffffffff816a8821>] ? __do_page_fault+0x171/0x450
[   61.523252]  [<ffffffff81214901>] SyS_ioctl+0xa1/0xc0
[   61.523255]  [<ffffffff816ada3d>] system_call_fastpath+0x16/0x1b
[   61.523256] ---[ end trace 396ec76cb81be1e6 ]---
[   61.523257] Failed to create /proc/enhanceio/bigcache
[   61.523259] cache_create: Device is already cached.
